### PR TITLE
try using local exec if "elm-make" could not be found in your path

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,9 +89,13 @@ function make(options){
       var deferred = Q.defer();
       which(opts.exe, function(err, exe){
         if(!!err){
-          deferred.reject({state: state, message: 'Failed to find ' + gutil.colors.magenta(opts.exe) + ' in your path.'});
+          console.log(gutil.colors.yellow('WARN: ') + 'Failed to find ' + gutil.colors.magenta("elm-make") + ' in your path. Trying to use local ' + opts.exe)
+          state.exe = opts.exe;
+//      deferred.reject({state: state, message: 'Failed to find ' + gutil.colors.magenta(opts.exe) + ' in your path.'});
         }
-        state.exe = exe;
+    		else{
+    			state.exe = exe;
+    		}
         deferred.resolve(state);
       });
       return deferred.promise;


### PR DESCRIPTION
When using together with [Elm binary wrapper](https://www.npmjs.com/package/elm)
and passing elm make in options. elm-make could not be found on Mac PATH when using
`which` and promise was rejected.
Commit changes error into warning and if elm-make was not found in PATH tries to use exec location passed in options.
Example usage:
```
var options = {elmMake:"./node_modules/elm/vendor/elm-make"};
gulp.task('elm-init', function(){
	elm.init(options);
});
gulp.task('elm', ['elm-init'], function(){
	return gulp.src(config.src+'/my-module/*.elm')
		.pipe(elm.make(options))
		.pipe(gulp.dest(config.destElm));
});
```
Will show warning on Mac but will run on Windows with no problems
