### PR TITLE
avoid error crashing gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ var elm  = require('gulp-elm');
 gulp.task('elm-init', elm.init);
 
 gulp.task('elm', ['elm-init'], function(){
+    function onErrorHandler(err) {
+        console.log(err);
+    }
+
   return gulp.src('src/*.elm')
     .pipe(elm())
+    .on('error', onErrorHandler)
     .pipe(gulp.dest('dist/'));
 });
 ```


### PR DESCRIPTION
With your current model code gulp was crashing whenever I got a compile error. I've now learnt how to handle that so my watches stay alive, and wanted to share this with you.

What is the purpose of the your `init` method, as I can't work it out?

An alternative would be to put the error handler code inside your transform function