### PR TITLE
Add `bundle` function that compile and bundle multiple elm files into a single .js file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 dest
 elm-stuff
+npm-debug.log
+typings
+.vscode

--- a/README.md
+++ b/README.md
@@ -45,3 +45,15 @@ compile elm files.
     elm output file type.
 
     js(javascript) or html.
+
+### `bundle`
+
+compile and bundle elm files into a single file.
+
+#### options
+
+* output (default: "bundle.js")
+
+    set the output file name for the --output option to elm-make.
+
+and all available options from `elm` / `elm.make`

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,13 +1,14 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/USER/PROJECT.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
         "."
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "1.0.0 <= v < 2.0.0"
-    }
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function processMakeOptions(options) {
   var args   = defaultArgs
   , ext    = '.js'
   , exe    = elm_make
-  , output = null;
+  , output = 'bundle.js';
 
   if(!!options){
     var yes = options.yesToAllPrompts;
@@ -220,10 +220,6 @@ function make(options){
 
   } // end of transform
 
-  if (opts.args.findIndex(value => value.startsWith('--output ')) > 0) {
-    return bundle(options); 
-  }
-  
   return through.obj(transform);
 }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var gutil         = require('gulp-util')
   , through       = require('through2')
-  , reduce        = require('through2-reduce')
   , which         = require('which')
   , fs            = require('fs')
   , path          = require('path')

--- a/index.js
+++ b/index.js
@@ -68,126 +68,156 @@ function init(options) {
   return deferred.promise;
 }
 
+function whichHandler(opts) {
+  return function(state){
+    state.phase = 'which';
+    var deferred = Q.defer();
+    which(opts.exe, function(err, exe){
+      if(!!err){
+        deferred.reject({state: state, message: 'Failed to find ' + gutil.colors.magenta(opts.exe) + ' in your path.'});
+      }
+      state.exe = exe;
+      deferred.resolve(state);
+    });
+    return deferred.promise;
+  }.bind(this);
+}
+   
+function tempHandler(opts) {
+  return function(state){
+    state.phase = 'make temp dir';
+    var deferred = Q.defer();
+    temp.mkdir({prefix: 'gulp-elm-tmp-'}, function(err, dirPath){
+      if(err){deferred.reject({state: state, message: 'cannot make temporary directory.'}); }
+      state.tmpDir = dirPath;
+      state.tmpOut = temp.path({dir: state.dirPath, suffix: opts.ext});
+      deferred.resolve(state);
+    });
+    return deferred.promise;
+  }.bind(this);
+}  
+
+function checkInputExistsHandler(opts, file) {
+  return function(state){
+    state.phase = 'check input';
+    var deferred = Q.defer();
+    state.tmpOut = temp.path({dir: state.dirPath, suffix: opts.ext});
+    state.input  = file.path;
+    state.tmpInput = false;
+
+    fs.exists(state.input, function(exists){
+      if(!exists) {
+        state.tmpInput = true;
+        state.input = temp.path({dir: state.dirPath, suffix: file.relative});
+        fs.writeFile(state.input, file.contents, function(){
+          deferred.resolve(state);
+        });
+      }
+      deferred.resolve(state);
+    });
+    return deferred.promise;
+  }.bind(this)
+}
+    
+function compileHandler(opts, file) { 
+  return function(state){
+    state.phase = 'compile';
+    var deferred = Q.defer()
+    , args = opts.args.concat(state.input, '--output', state.tmpOut);
+    state.output = path.resolve(process.cwd(), path.basename(file.path, path.extname(file.path)) + opts.ext);
+    compile(state.exe, args, function(err){
+      if(!!err) { deferred.reject({state: state, message: err}); }
+      else      { deferred.resolve(state); }
+    });
+    return deferred.promise;
+  }.bind(this);
+}
+    
+function bundleHandler(opts, files) {
+  return function(state){
+    state.phase = 'compile';
+    state.output = path.resolve(process.cwd(), opts.output);
+
+    var deferred = Q.defer()
+    , args = opts.args.concat(files, '--output', state.tmpOut);
+    compile(state.exe, args, function(err){
+      if(!!err) { deferred.reject({state: state, message: err}); }
+      else      { deferred.resolve(state); }
+    });
+    return deferred.promise;
+  }.bind(this);
+}
+    
+function pushResultHandler() {
+  return function(state){
+    state.phase = 'push';
+    var deferred = Q.defer();
+    fs.readFile(state.tmpOut, function(err, contents){
+      if(!!err) {deferred.reject({state: state, message: err}); }
+      this.push(new gutil.File({
+        path: state.output,
+        contents: contents
+      }));
+      deferred.resolve(state);
+    }.bind(this));
+    return deferred.promise;
+  }.bind(this);
+}
+  
+function failHandler() {
+  return function(rej){
+    this.emit('error', new gutil.PluginError(PLUGIN, rej.message));
+    return rej.state;
+  }.bind(this);
+}
+  
+function doneHandler(callback) { 
+  return function(state){
+
+    function next() {
+      fs.unlink(state.tmpOut, function(){
+        fs.rmdir(state.tmpDir, function(){
+        callback();
+        });
+      });
+    }
+
+    if(state.tmpInput) {
+      fs.unlink(state.input, function(){
+        next();
+      });
+    } else {
+      next();
+    }
+  }.bind(this);
+}
+
 function make(options){
   var opts = processMakeOptions(options);
 
   function transform(file, encode, callback) {
-    var _this = this;
 
     // null
     if(file.isNull()) {
-      _this.push(file);
+      this.push(file);
       return callback();
     }
 
     // stream
     if(file.isStream()){
-      _this.emit('error', new gutil.PluginError(PLUGIN, 'Streams are not supported!'));
+      this.emit('error', new gutil.PluginError(PLUGIN, 'Streams are not supported!'));
       return callback();
     }
 
     // buffer
     Q.when({phase: 'start'})
-
-    // which
-    .then(function(state){
-      state.phase = 'which';
-      var deferred = Q.defer();
-      which(opts.exe, function(err, exe){
-        if(!!err){
-          deferred.reject({state: state, message: 'Failed to find ' + gutil.colors.magenta(opts.exe) + ' in your path.'});
-        }
-        state.exe = exe;
-        deferred.resolve(state);
-      });
-      return deferred.promise;
-    })
-
-    // make temp dir
-    .then(function(state){
-      state.phase = 'make temp dir';
-      var deferred = Q.defer();
-      temp.mkdir({prefix: 'gulp-elm-tmp-'}, function(err, dirPath){
-        if(err){deferred.reject({state: state, message: 'cannot make temporary directory.'}); }
-        state.tmpDir = dirPath;
-        deferred.resolve(state);
-      });
-      return deferred.promise;
-    })
-
-    // check input exists
-    .then(function(state){
-      state.phase = 'check input';
-      var deferred = Q.defer();
-      state.tmpOut = temp.path({dir: state.dirPath, suffix: opts.ext});
-      state.input  = file.path;
-      state.tmpInput = false;
-
-      fs.exists(state.input, function(exists){
-        if(!exists) {
-          state.tmpInput = true;
-          state.input = temp.path({dir: state.dirPath, suffix: file.relative});
-          fs.writeFile(state.input, file.contents, function(){
-            deferred.resolve(state);
-          });
-        }
-        deferred.resolve(state);
-      });
-      return deferred.promise;
-    })
-
-    // compile
-    .then(function(state){
-      state.phase = 'compile';
-      var deferred = Q.defer()
-      , args = opts.args.concat(state.input, '--output', state.tmpOut);
-      state.output = path.resolve(process.cwd(), path.basename(file.path, path.extname(file.path)) + opts.ext);
-      compile(state.exe, args, function(err){
-        if(!!err) { deferred.reject({state: state, message: err}); }
-        else      { deferred.resolve(state); }
-      });
-      return deferred.promise;
-    })
-
-    // push result
-    .then(function(state){
-      state.phase = 'push';
-      var deferred = Q.defer();
-      fs.readFile(state.tmpOut, function(err, contents){
-        if(!!err) {deferred.reject({state: state, message: err}); }
-        _this.push(new gutil.File({
-          path: state.output,
-          contents: contents
-        }));
-        deferred.resolve(state);
-      });
-      return deferred.promise;
-    })
-
-    .fail(function(rej){
-      _this.emit('error', new gutil.PluginError(PLUGIN, rej.message));
-      return rej.state;
-    })
-
-    .done(function(state){
-
-      function next() {
-        fs.unlink(state.tmpOut, function(){
-          fs.rmdir(state.tmpDir, function(){
-          callback();
-          });
-        });
-      }
-
-      if(state.tmpInput) {
-        fs.unlink(state.input, function(){
-          next();
-        });
-      } else {
-        next();
-      }
-
-    });
+    .then(whichHandler.apply(this, [opts]))
+    .then(tempHandler.apply(this, [opts]))
+    .then(checkInputExistsHandler(opts, file))
+    .then(compileHandler.apply(this, [opts, file]))
+    .then(pushResultHandler.apply(this))
+    .fail(failHandler.apply(this))
+    .done(doneHandler.apply(this, [callback]));
 
   } // end of transform
 
@@ -208,91 +238,15 @@ function bundle(options) {
   }
   
   function endStream(callback) {
-    var _this = this;
-
+    
     // buffer
     Q.when({phase: 'start'})
-
-    // which
-    .then(function(state){
-      state.phase = 'which';
-      var deferred = Q.defer();
-      which(opts.exe, function(err, exe){
-        if(!!err){
-          deferred.reject({state: state, message: 'Failed to find ' + gutil.colors.magenta(opts.exe) + ' in your path.'});
-        }
-        state.exe = exe;
-        deferred.resolve(state);
-      });
-      return deferred.promise;
-    })
-
-    // make temp dir
-    .then(function(state){
-      state.phase = 'make temp dir';
-      var deferred = Q.defer();
-      temp.mkdir({prefix: 'gulp-elm-tmp-'}, function(err, dirPath){
-        if(err){deferred.reject({state: state, message: 'cannot make temporary directory.'}); }
-        state.tmpDir = dirPath;
-        deferred.resolve(state);
-      });
-      state.tmpOut = temp.path({dir: state.dirPath, suffix: opts.ext});
-      return deferred.promise;
-    })
-
-    // compile
-    .then(function(state){
-      state.phase = 'compile';
-      state.output = path.resolve(process.cwd(), opts.output);
-
-      var deferred = Q.defer()
-      , args = opts.args.concat(files, '--output', state.tmpOut);
-      compile(state.exe, args, function(err){
-        if(!!err) { deferred.reject({state: state, message: err}); }
-        else      { deferred.resolve(state); }
-      });
-      return deferred.promise;
-    })
-
-    // push result
-    .then(function(state){
-      state.phase = 'push';
-      var deferred = Q.defer();
-      fs.readFile(state.tmpOut, function(err, contents){
-        if(!!err) {deferred.reject({state: state, message: err}); }
-        _this.push(new gutil.File({
-          path: state.output,
-          contents: contents
-        }));
-        deferred.resolve(state);
-      });
-      return deferred.promise;
-    })
-
-    .fail(function(rej){
-      _this.emit('error', new gutil.PluginError(PLUGIN, rej.message));
-      return rej.state;
-    })
-
-    .done(function(state){
-
-      function next() {
-        fs.unlink(state.tmpOut, function(){
-          fs.rmdir(state.tmpDir, function(){
-            callback();
-          });
-        });
-      }
-
-      if(state.tmpInput) {
-        fs.unlink(state.input, function(){
-          next();
-        });
-      } else {
-        next();
-      }
-
-    });
+    .then(whichHandler.apply(this, [opts]))
+    .then(tempHandler.apply(this, [opts]))
+    .then(bundleHandler.apply(this, [opts, files]))
+    .then(pushResultHandler.apply(this))
+    .fail(failHandler.apply(this))
+    .done(doneHandler.apply(this, [callback]));
   }
   
   return through.obj(transform, endStream);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-elm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "elm compiler for Gulp",
   "license": "MIT",
   "repository": {

--- a/test/fail.elm
+++ b/test/fail.elm
@@ -1,6 +1,6 @@
 module Fail where
 
-import Text(plainText)
+import Text (plainText)
 iport Graphics.Element(tag)
 
 main = tag "hello" <| plainText "Test"

--- a/test/main.js
+++ b/test/main.js
@@ -74,6 +74,7 @@ describe('gulp-elm', function(){
     myElm.once('data', function(file){
       assert(file.isBuffer());
       assert.equal(file.relative, output);
+      done();
     });
   });
 

--- a/test/main.js
+++ b/test/main.js
@@ -21,21 +21,21 @@ function checkTest1(done){
 }
 
 describe('gulp-elm', function(){
-
+  
   before(function(done){
     this.timeout(30000);
     elm.init().then(done);
   });
-
+  
   it('should compile Elm to js from virtual file.', function(done){
     var myElm = elm();
-    myElm.write(new gutil.File({path: "dummy", contents: fs.readFileSync('test/test.elm')}));
+    myElm.write(new gutil.File({path: "dummy", contents: fs.readFileSync('test/test1.elm')}));
     myElm.once('data', checkTest1(done));
   });
 
   it('should compile Elm to js from real file.', function(done){
     var myElm = elm();
-    myElm.write(new gutil.File({path: "test/test.elm", contents: new Buffer('dummy')}));
+    myElm.write(new gutil.File({path: "test/test1.elm", contents: new Buffer('dummy')}));
     myElm.once('data', checkTest1(done));
   });
 
@@ -51,7 +51,7 @@ describe('gulp-elm', function(){
 
   it('should compile Elm to html from real file.', function(done){
     var myElm = elm({filetype: 'html'});
-    myElm.write(new gutil.File({path: "test/test.elm", contents: new Buffer('dummy')}));
+    myElm.write(new gutil.File({path: "test/test1.elm", contents: new Buffer('dummy')}));
     myElm.once('data', function(file){
       assert(file.isBuffer());
 
@@ -65,4 +65,16 @@ describe('gulp-elm', function(){
       });
     });
   });
+
+  it('should bundle Elm files to js from virtual file.', function(done){
+    var output = "bundle.js";
+    var myElm = elm.bundle({output: output});
+    myElm.write(new gutil.File({path: "test/test1.elm", contents: fs.readFileSync('test/test1.elm')}));
+    myElm.end(new gutil.File({path: "test/test2.elm", contents: fs.readFileSync('test/test2.elm')}));
+    myElm.once('data', function(file){
+      assert(file.isBuffer());
+      assert.equal(file.relative, output);
+    });
+  });
+
 });

--- a/test/test.elm
+++ b/test/test.elm
@@ -1,6 +1,0 @@
-module Test1 where
-
-import Text(plainText)
-import Graphics.Element(tag)
-
-main = tag "hello" <| plainText "Test"

--- a/test/test1.elm
+++ b/test/test1.elm
@@ -1,0 +1,6 @@
+module Test1 where
+
+import Text exposing (fromString)
+import Graphics.Element exposing (tag, leftAligned)
+
+main = tag "hello" <| leftAligned <| fromString "Test" 

--- a/test/test2.elm
+++ b/test/test2.elm
@@ -1,0 +1,6 @@
+module Test2 where
+
+import Text exposing (fromString)
+import Graphics.Element exposing (tag, leftAligned)
+
+main = tag "hello" <| leftAligned <| fromString "Test" 


### PR DESCRIPTION
I implements "bundling" functionality by passing multiple `.elm` files to a single `elm-make` call and compiled to a single `.js` file, basically calling this command:
```shell
elm-make --yes file1.elm file2.elm file3.elm --output bundle.js
```

Here's how you'll use in in gulp:
```javascript
gulp.task('elm', ['elm-init'], function(){
  return gulp.src('src/*.elm')
    .pipe(elm.bundle({output: "bundle.js"}))
    .pipe(gulp.dest('dist/'));
});
```
I also refactored the main flow of the make in order to be able to re-use a lot of the code in the `bundle` function, and updated the unit test to work with elm v0.16.0.

Let me know if you see anything that you want to change, I will be happy to discuss it.