### PR TITLE
Replace child_process with cross-spawn-async for better support on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var gutil         = require('gulp-util')
   , fs            = require('fs')
   , path          = require('path')
   , temp          = require('temp')
-  , child_process = require('child_process')
+  , spawn         = require('cross-spawn-async')
   , Q             = require('q')
   , elm_make      = 'elm-make'
   , defaultArgs   = ['--yes']
@@ -41,7 +41,7 @@ function processMakeOptions(options, output) {
 }
 
 function compile(exe, args, callback){
-  var proc    = child_process.spawn(exe, args)
+  var proc    = spawn(exe, args)
     , bStderr = new Buffer(0);
 
   proc.stderr.on('data', function(stderr){

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "q": "^1.1.2",
     "temp": "^0.8.1",
     "through2": "^0.6.3",
-    "which": "^1.0.8"
+    "which": "^1.0.8",
+    "cross-spawn-async": "^2.1.9"
   },
   "devDependencies": {
     "jsdom": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-elm",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "elm compiler for Gulp",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This PR is to fix issue with running gulp-elm in windows when the path to elm-make and/or .elm files contain spaces.