### PR TITLE
Use terminal's stderr when displaying compiler's error message.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "3.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.15.0 <= v < 0.18.0"
 }

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,14 +1,14 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/USER/PROJECT.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
         "elm"
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.0.1 <= v < 3.0.0"
+        "elm-lang/core": "3.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.15.0 <= v < 0.18.0"
 }

--- a/index.js
+++ b/index.js
@@ -41,12 +41,7 @@ function processMakeOptions(options, output) {
 }
 
 function compile(exe, args, callback){
-  var proc    = spawn(exe, args, {stdio: ['ignore', 'ignore', 2]})
-    // , bStderr = new Buffer(0);
-
-  // proc.stderr.on('data', function(stderr){
-    // bStderr = Buffer.concat([bStderr, new Buffer(stderr)]);
-  // });
+  var proc    = spawn(exe, args, {stdio: ['ignore', 'ignore', process.stderr]})
 
   proc.on('close', function(code){
     if(!!code) { callback("Compile error"); }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function processMakeOptions(options, output) {
 }
 
 function compile(exe, args, callback){
-  var proc    = spawn(exe, args, {stdio: ['ignore', 'ignore', process.stderr]})
+  var proc    = spawn(exe, args, {stdio: ['ignore', process.stdout, process.stderr]})
 
   proc.on('close', function(code){
     if(!!code) { callback("Compile error"); }

--- a/index.js
+++ b/index.js
@@ -41,16 +41,16 @@ function processMakeOptions(options, output) {
 }
 
 function compile(exe, args, callback){
-  var proc    = spawn(exe, args)
-    , bStderr = new Buffer(0);
+  var proc    = spawn(exe, args, {stdio: ['ignore', 'ignore', 2]})
+    // , bStderr = new Buffer(0);
 
-  proc.stderr.on('data', function(stderr){
-    bStderr = Buffer.concat([bStderr, new Buffer(stderr)]);
-  });
+  // proc.stderr.on('data', function(stderr){
+    // bStderr = Buffer.concat([bStderr, new Buffer(stderr)]);
+  // });
 
   proc.on('close', function(code){
-    if(!!code) { callback(bStderr.toString()); }
-    callback(null, bStderr.toString());
+    if(!!code) { callback("Compile error"); }
+    callback(null, "");
   });
 }
 
@@ -166,6 +166,7 @@ function pushResultHandler() {
 
 function failHandler() {
   return function(rej){
+    console.log(rej.message);
     this.emit('error', new gutil.PluginError(PLUGIN, rej.message));
       return rej.state;
   }.bind(this);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-elm",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "elm compiler for Gulp",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "temp": "^0.8.1",
     "through2": "^0.6.3",
     "which": "^1.0.8",
-    "cross-spawn-async": "^2.1.9"
+    "cross-spawn-async": "^2.2.2"
   },
   "devDependencies": {
     "jsdom": "^1.5.0",


### PR DESCRIPTION
Inherit the parent's stderror when spawing compiler child process to keep the ansi color on the compiler error message.