### PR TITLE
Do not fail when given zero files

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,9 @@ function bundle(output, options) {
   }
 
   function endStream(callback) {
-
+    if (files.length === 0){
+      return;
+    }
     // buffer
     Q.when({phase: 'start'})
     .then(whichHandler.apply(this, [opts]))

--- a/test/main.js
+++ b/test/main.js
@@ -78,6 +78,16 @@ describe('gulp-elm', function(){
     });
   });
 
+  it('should not error when bundling 0 Elm files.', function(done){
+    var output = "bundle.js";
+    var myElm = elm.bundle(output);
+    myElm.end();
+    myElm.once('data', function(file){
+      assert.fail('Should not have any data');
+    });
+    setTimeout(done, 1000);
+  });
+
   it('should error when output does not match filetype.', function(){
     var output = "bundle.js";
     try {


### PR DESCRIPTION
When using `bundle`, there is an error if zero files are provided.