### PR TITLE
Partial upgrade of tests to 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,7 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 5.0.0"
+        "elm-lang/core": "3.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "evancz/elm-graphics": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.18.0"
 }

--- a/test/fail.elm
+++ b/test/fail.elm
@@ -1,6 +1,6 @@
-module Fail where
+module Fail exposing (..)
 
 import Text (plainText)
-iport Graphics.Element(tag)
+iport Element(tag)
 
-main = tag "hello" <| plainText "Test"
+main = toHtml <| tag "hello" <| plainText "Test"

--- a/test/main.js
+++ b/test/main.js
@@ -10,7 +10,7 @@ function checkTest1(done){
 
     jsdom.env({
       html: '<html></html>',
-      src:  [file.contents, "Elm.fullscreen(Elm.Test1)"],
+      src:  [file.contents, "Elm.Test1.fullscreen()"],
       done: function(err, window){
         assert(!err);
         assert.equal(window.document.getElementById("hello").innerHTML, "Test");
@@ -21,12 +21,12 @@ function checkTest1(done){
 }
 
 describe('gulp-elm', function(){
-  
+
   before(function(done){
     this.timeout(30000);
     elm.init().then(done);
   });
-  
+
   it('should compile Elm to js from virtual file.', function(done){
     var myElm = elm();
     myElm.write(new gutil.File({path: "dummy", contents: fs.readFileSync('test/test1.elm')}));
@@ -59,7 +59,7 @@ describe('gulp-elm', function(){
         html: file.contents,
         done: function(err, window){
           assert(!err);
-          assert.equal(window.document.getElementsByTagName('script')[1].innerHTML, "Elm.fullscreen(Elm.Test1)");
+          assert.equal(window.document.getElementsByTagName('script')[1].innerHTML, "Elm.Test1.fullscreen()");
           done();
         }
       });

--- a/test/test1.elm
+++ b/test/test1.elm
@@ -1,6 +1,8 @@
-module Test1 where
+module Test1 exposing (..)
 
-import Text exposing (fromString)
-import Graphics.Element exposing (tag, leftAligned)
+import Html exposing (div, text)
+import Html.Attributes exposing (id)
 
-main = tag "hello" <| leftAligned <| fromString "Test" 
+
+main =
+    div [ id "hello" ] [ text "Test" ]

--- a/test/test2.elm
+++ b/test/test2.elm
@@ -1,6 +1,8 @@
-module Test2 where
+module Test2 exposing (..)
 
 import Text exposing (fromString)
-import Graphics.Element exposing (tag, leftAligned)
+import Element exposing (tag, leftAligned, toHtml)
 
-main = tag "hello" <| leftAligned <| fromString "Test" 
+
+main =
+    toHtml <| tag "hello" <| leftAligned <| fromString "Test"


### PR DESCRIPTION
This is a work in progress, there are still two failing tests

Update module syntax
Add packages where types moved
Use HTML library for test (though it's still not working)
- The graphics test causes an error because it tries to access document.body and it runs in the head (before body is defined)
  Update expected JavaScript for fullscreen
