### PR TITLE
Using local elm-make if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var gutil         = require('gulp-util')
   , temp          = require('temp')
   , spawn         = require('cross-spawn')
   , Q             = require('q')
+  , elm_make_dev  = 'node_modules/.bin/elm-make'
   , elm_make      = 'elm-make'
   , defaultArgs   = ['--yes']
   , PLUGIN        = 'gulp-elm';
@@ -15,7 +16,7 @@ var gutil         = require('gulp-util')
 function processMakeOptions(options, output) {
   var args   = defaultArgs
     , ext    = '.js'
-    , exe    = elm_make;
+    , exe    = fs.existsSync(elm_make_dev) && fs.statSync(elm_make_dev).isFile() ? elm_make_dev : elm_make;
 
   if(!!options){
     var yes = options.yesToAllPrompts;
@@ -36,7 +37,7 @@ function processMakeOptions(options, output) {
       if (output && path.extname(output) !== ext) { throw new gutil.PluginError(PLUGIN, 'output is ' + path.extname(output) + ', but filetype is ' + ext); }
     }
   }
-
+    
   return {args: args, ext: ext, exe: exe};
 }
 


### PR DESCRIPTION
Added changes to detect if local elm installation is present and use it instead of global one.

It checks if there is an `elm-make` in `node_modules/.bin/` directory and it picks that one if present. Otherwise it falls back to the `elm-make` from the path.

I added this change to be able to build the project with the elm version defined in package.json. I have different project with different elm version (0.16 and 0.17) and unfortunately 0.17 can not compile 0.16 code.